### PR TITLE
Revert "[irods/irods#4627] Bump externals to match 4-2-stable"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ project(irods_rule_engine_plugin_audit_amqp C CXX)
 
 include(${IRODS_TARGETS_PATH})
 
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
   set(CPACK_PACKAGING_INSTALL_PREFIX "/" CACHE STRING "Package root path. \"/\" is correct for normal package builds.." FORCE)
   message(STATUS "Setting unspecified CPACK_PACKAGING_INSTALL_PREFIX to '${CPACK_PACKAGING_INSTALL_PREFIX}'. This is the correct setting for normal builds.")
@@ -33,52 +35,82 @@ macro(IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH DEPENDENCY_NAME DEPENDENCY_
   set(IRODS_EXTERNALS_FULLPATH_${DEPENDENCY_NAME} ${IRODS_EXTERNALS_PACKAGE_ROOT}/${DEPENDENCY_SUBDIRECTORY})
 endmacro()
 
-IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH(JANSSON jansson2.7-0)
-IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH(QPID qpid-with-proton0.34-1)
+IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH(QPID qpid-with-proton0.34-0)
 
-set(CMAKE_COMPILE_COMMANDS TRUE)
+set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
+set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
 
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-set(CMAKE_INSTALL_RPATH ${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++ -Wl,-z,defs")
+find_package(OpenSSL REQUIRED)
 
-set(PLUGIN irods_rule_engine_plugin-audit_amqp)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,defs")
+add_compile_options(-nostdinc++)
+add_compile_options(-std=c++14)
+link_libraries(c++abi)
+include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1)
 
-add_library(${PLUGIN} MODULE ${CMAKE_SOURCE_DIR}/libirods_rule_engine_plugin-audit_amqp.cpp)
-set_target_properties(${PLUGIN} PROPERTIES CXX_STANDARD ${IRODS_CXX_STANDARD})
-target_compile_options(${PLUGIN} PRIVATE -Wno-write-strings -nostdinc++)
-target_compile_definitions(${PLUGIN} PRIVATE ${IRODS_COMPILE_DEFINITIONS})
-target_include_directories(
-  ${PLUGIN}
-  PRIVATE
-  ${IRODS_INCLUDE_DIRS}
-  ${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/include
-  ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
-  ${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1
-  ${IRODS_EXTERNALS_FULLPATH_JANSSON}/include
-  ${IRODS_EXTERNALS_FULLPATH_JSON}/include
-  ${IRODS_EXTERNALS_FULLPATH_QPID}/include
+set(
+  IRODS_RULE_ENGINE_PLUGIN_AUDIT_AMQP_COMPILE_DEFINITIONS
+  RODS_SERVER
+  ENABLE_RE
   )
 
-target_link_libraries(
-  ${PLUGIN}
-  PRIVATE
+set(
+  IRODS_RULE_ENGINE_PLUGIN_AUDIT_AMQP_LINK_LIBRARIES
   irods_server
-  irods_common
-  ${IRODS_EXTERNALS_FULLPATH_JANSSON}/lib/libjansson.so
-  ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpidclient.so
-  ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpidcommon.so
-  ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpidmessaging.so
-  ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpid-proton.so
-  ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpid-proton-cpp.so
-  ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so
-  ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
-  dl
-  c++abi
   )
 
-install(TARGETS ${PLUGIN} LIBRARY DESTINATION ${IRODS_PLUGINS_DIRECTORY}/rule_engines)
+set(
+  PLUGIN
+  irods_rule_engine_plugin-audit_amqp
+  )
+
+  add_library(
+      ${PLUGIN}
+      MODULE
+      ${CMAKE_SOURCE_DIR}/libirods_rule_engine_plugin-audit_amqp.cpp
+      )
+
+  target_include_directories(
+      ${PLUGIN}
+      PRIVATE
+      ${IRODS_INCLUDE_DIRS}
+      ${IRODS_EXTERNALS_FULLPATH_QPID}/include
+      ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+      ${IRODS_EXTERNALS_FULLPATH_JANSSON}/include
+      ${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/include
+      )
+
+  target_link_libraries(
+      ${PLUGIN}
+      PRIVATE
+      ${IRODS_RULE_ENGINE_PLUGIN_AUDIT_AMQP_LINK_LIBRARIES}
+      ${IRODS_EXTERNALS_FULLPATH_JANSSON}/lib/libjansson.so
+      ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpidclient.so
+      ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpidcommon.so
+      ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpidmessaging.so
+      ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpid-proton.so
+      ${IRODS_EXTERNALS_FULLPATH_QPID}/lib/libqpid-proton-cpp.so
+      ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
+      ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so
+      ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+      ${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/lib/libarchive.so
+      ${OPENSSL_CRYPTO_LIBRARY}
+      irods_common
+      )
+
+  target_compile_definitions(${PLUGIN} PRIVATE ${IRODS_RULE_ENGINE_PLUGIN_AUDIT_AMQP_COMPILE_DEFINITIONS} ${IRODS_COMPILE_DEFINITIONS} BOOST_SYSTEM_NO_DEPRECATED)
+  target_compile_options(${PLUGIN} PRIVATE -Wno-write-strings)
+  set_property(TARGET ${PLUGIN} PROPERTY CXX_STANDARD ${IRODS_CXX_STANDARD})
+
+install(
+  TARGETS
+  ${PLUGIN}
+  LIBRARY
+    DESTINATION usr/lib/irods/plugins/rule_engines
+  )
 
 install(
   FILES
@@ -161,13 +193,13 @@ set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/packaging/postinst")
 set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)
 
 set(CPACK_DEBIAN_PACKAGE_NAME "irods-rule-engine-plugin-audit-amqp")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime (= ${IRODS_VERSION}), libc6, irods-externals-qpid-with-proton0.34-1, irods-externals-jansson2.7-0")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime (= ${IRODS_VERSION}), libc6, irods-externals-qpid-with-proton0.34-0")
 
 set(CPACK_RPM_PACKAGE_NAME "irods-rule-engine-plugin-audit-amqp")
 if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos linux")
-  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, openssl, irods-externals-qpid-with-proton0.34-1, irods-externals-jansson2.7-0")
+  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, openssl, irods-externals-qpid-with-proton0.34-0")
 elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
-  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, libopenssl1_0_0, irods-externals-qpid-with-proton0.34-1, irods-externals-jansson2.7-0")
+  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, libopenssl1_0_0, irods-externals-qpid-with-proton0.34-0")
 endif()
 
 

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -10,20 +10,20 @@ import irods_python_ci_utilities
 
 
 def install_cmake_and_add_to_front_of_path():
-    irods_python_ci_utilities.install_os_packages(['irods-externals-cmake3.11.4-0'])
-    os.environ['PATH'] = '/opt/irods-externals/cmake3.11.4-0/bin' + os.pathsep + os.environ['PATH']
+    irods_python_ci_utilities.install_os_packages(['irods-externals-cmake3.5.2-0'])
+    os.environ['PATH'] = '/opt/irods-externals/cmake3.5.2-0/bin' + os.pathsep + os.environ['PATH']
 
 
 def get_build_prerequisites_all():
-    return ['irods-externals-avropre190cpp17-0',
-            'irods-externals-boost1.67.0-0',
-            'irods-externals-clang-runtime6.0-0',
-            'irods-externals-clang6.0-0',
-            'irods-externals-cppzmq4.2.3-0',
+    return ['irods-externals-clang3.8-0',
+            'irods-externals-cppzmq4.1-0',
+            'irods-externals-libarchive3.1.2-0',
+            'irods-externals-avro1.7.7-0',
+            'irods-externals-clang-runtime3.8-0',
+            'irods-externals-boost1.60.0-0',
             'irods-externals-jansson2.7-0',
-            'irods-externals-libarchive3.3.2-1',
-            'irods-externals-qpid-with-proton0.34-1',
-            'irods-externals-zeromq4-14.1.6-0']
+            'irods-externals-zeromq4-14.1.3-0',
+            'irods-externals-qpid-with-proton0.34-0']
 
 
 def get_build_prerequisites_apt():

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -43,6 +43,8 @@ def get_build_prerequisites():
 
 
 def install_build_prerequisites():
+    irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'pip', 'install', 'unittest-xml-reporting==1.14.0'])
+
     if irods_python_ci_utilities.get_distribution() == 'Ubuntu': # cmake from externals requires newer libstdc++ on ub12
         if irods_python_ci_utilities.get_distribution_version_major() == '12':
             irods_python_ci_utilities.install_os_packages(['python-software-properties'])
@@ -51,6 +53,29 @@ def install_build_prerequisites():
             irods_python_ci_utilities.install_os_packages(['libstdc++6'])
 
     irods_python_ci_utilities.install_os_packages(get_build_prerequisites())
+
+
+def install_qpid_proton():
+    local_qpid_proton_dir = tempfile.mkdtemp(prefix='qpid_proton_dir')
+    irods_python_ci_utilities.git_clone('https://github.com/apache/qpid-proton.git', '0.17.0', local_qpid_proton_dir)
+
+    if irods_python_ci_utilities.get_distribution() == 'Ubuntu':
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'gcc', 'cmake', 'cmake-curses-gui', 'uuid-dev', '-y'])
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'libssl-dev', '-y'])
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'libsasl2-2','libsasl2-dev', '-y'])
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'swig', 'python-dev', 'ruby-dev', 'libperl-dev', '-y'])
+    else:
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'yum', 'install', 'gcc', 'make', 'cmake', 'libuuid-devel', '-y'])
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'yum', 'install', 'openssl-devel', '-y'])
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'yum', 'install', 'cyrus-sasl-devel', '-y'])
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'yum', 'install', 'swig', 'python-devel', 'ruby-devel', 'rubygem-minitest', 'php-devel', 'perl-devel', '-y'])
+
+    qpid_proton_build_dir = local_qpid_proton_dir + '/build'
+    if not os.path.exists(qpid_proton_build_dir):
+        os.makedirs(qpid_proton_build_dir)
+        os.chdir(qpid_proton_build_dir)
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'cmake', '..', '-DCMAKE_INSTALL_PREFIX=/usr', '-DSYSINSTALL_BINDINGS=ON'])
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'make', 'install'])
 
 
 def install_messaging_package(message_broker):
@@ -100,29 +125,25 @@ def main():
     package_suffix = irods_python_ci_utilities.get_package_suffix()
     os_specific_directory = irods_python_ci_utilities.append_os_specific_directory(built_packages_root_directory)
 
-    install_build_prerequisites()
-    irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'pip', 'install', 'unittest-xml-reporting==1.14.0', 'python-qpid-proton==0.30.0'])
-    install_messaging_package(options.message_broker)
-
     irods_python_ci_utilities.install_os_packages_from_files(glob.glob(os.path.join(os_specific_directory, 'irods-rule-engine-plugin-audit-amqp*.{0}'.format(package_suffix))))
-    irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c', 'python scripts/add_audit_rule_engine_to_rule_engines.py'], check_rc=True)
+    irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c', 'python2 scripts/add_audit_rule_engine_to_rule_engines.py'], check_rc=True)
+
+    install_build_prerequisites()
+    install_qpid_proton()
+    install_messaging_package(options.message_broker)
 
     time.sleep(10)
 
-    test_audit_log = 'log/test_audit_plugin.log'
-    test_output_file = 'log/test_output.log'
     try:
+        test_audit_log = 'log/test_audit_plugin.log'
+        test_output_file = 'log/test_output.log'
         irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c', 'python2 scripts/run_tests.py --xml_output --run_s=test_audit_plugin 2>&1 | tee {0}; exit $PIPESTATUS'.format(test_audit_log)], check_rc=True)
         irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c', 'python2 scripts/run_tests.py --xml_output --run_s=test_resource_types.Test_Resource_Unixfilesystem 2>&1 | tee {0}; exit $PIPESTATUS'.format(test_output_file)], check_rc=True)
     finally:
         if output_root_directory:
             irods_python_ci_utilities.gather_files_satisfying_predicate('/var/lib/irods/log', output_root_directory, lambda x: True)
-            test_output_file = os.path.join('/var/lib/irods', test_output_file)
-            if os.path.exists(test_output_file):
-                shutil.copy(test_output_file, output_root_directory)
-            test_audit_log = os.path.join('/var/lib/irods', test_audit_log)
-            if os.path.exists(test_audit_log):
-                shutil.copy(test_audit_log, output_root_directory)
+            shutil.copy('/var/lib/irods/log/test_output.log', output_root_directory)
+            shutil.copy('/var/lib/irods/log/test_audit_plugin.log', output_root_directory)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverts commit a39af94bb2358fa48976d75bebb1ec1b144ce1cf.

There is a planned release of this plugin against iRODS server version 4.2.7 and these changes make the plugin incompatible with previous server versions.