### PR TITLE
Changes allowing audit plugin to work under Ubuntu 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ macro(IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH DEPENDENCY_NAME DEPENDENCY_
 endmacro()
 
 IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH(JANSSON jansson2.7-0)
-IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH(QPID qpid-with-proton0.34-1)
+IRODS_MACRO_SET_AND_CHECK_DEPENDENCY_FULL_PATH(QPID qpid-with-proton0.34-2)
 
 set(CMAKE_COMPILE_COMMANDS TRUE)
 
@@ -159,13 +159,13 @@ set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/packaging/postinst")
 set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)
 
 set(CPACK_DEBIAN_PACKAGE_NAME "irods-rule-engine-plugin-audit-amqp")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime (= ${IRODS_VERSION}), libc6, irods-externals-qpid-with-proton0.34-1, irods-externals-jansson2.7-0")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime (= ${IRODS_VERSION}), libc6, irods-externals-qpid-with-proton0.34-2, irods-externals-jansson2.7-0")
 
 set(CPACK_RPM_PACKAGE_NAME "irods-rule-engine-plugin-audit-amqp")
 if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos linux")
-  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, openssl, irods-externals-qpid-with-proton0.34-1, irods-externals-jansson2.7-0")
+  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, openssl, irods-externals-qpid-with-proton0.34-2, irods-externals-jansson2.7-0")
 elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
-  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, libopenssl1_0_0, irods-externals-qpid-with-proton0.34-1, irods-externals-jansson2.7-0")
+  set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, libopenssl1_0_0, irods-externals-qpid-with-proton0.34-2, irods-externals-jansson2.7-0")
 endif()
 
 

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -21,10 +21,12 @@ def install_building_dependencies(externals_directory):
                       'irods-externals-clang-runtime6.0-0',
                       'irods-externals-clang6.0-0',
                       'irods-externals-cppzmq4.2.3-0',
+                      'irods-externals-fmt6.1.2-1',
                       'irods-externals-json3.7.3-0',
                       'irods-externals-jansson2.7-0',
                       'irods-externals-libarchive3.3.2-1',
-                      'irods-externals-qpid-with-proton0.34-1',
+                      'irods-externals-nanodbc2.13.0-0',
+                      'irods-externals-qpid-with-proton0.34-2',
                       'irods-externals-zeromq4-14.1.6-0']
     if externals_directory == 'None' or externals_directory is None:
         irods_python_ci_utilities.install_irods_core_dev_repository()

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -13,13 +13,7 @@ def get_build_prerequisites_all():
     return['gcc', 'swig']
 
 def get_build_prerequisites_apt():
-    pre_reqs = ['uuid-dev', 'libssl-dev', 'libsasl2-2', 'libsasl2-dev', 'python-dev']
-    if irods_python_ci_utilities.get_distribution_version_major() == '12':
-        pre_reqs = pre_reqs+['openjdk-7-jre']
-    else:
-        pre_reqs = pre_reqs+['default-jre']
-    
-    return get_build_prerequisites_all()+pre_reqs
+    return get_build_prerequisites_all()+['default-jre','uuid-dev', 'libssl-dev', 'libsasl2-2', 'libsasl2-dev', 'python-dev']
 
 def get_build_prerequisites_yum():
     return get_build_prerequisites_all()+['java-1.7.0-openjdk-devel', 'libuuid-devel', 'openssl-devel', 'cyrus-sasl-devel', 'python-devel']
@@ -40,13 +34,6 @@ def get_build_prerequisites():
         irods_python_ci_utilities.raise_not_implemented_for_distribution()
 
 def install_build_prerequisites():
-    if irods_python_ci_utilities.get_distribution() == 'Ubuntu': # cmake from externals requires newer libstdc++ on ub12
-        if irods_python_ci_utilities.get_distribution_version_major() == '12':
-            irods_python_ci_utilities.install_os_packages(['python-software-properties'])
-            irods_python_ci_utilities.subprocess_get_output(['sudo', 'add-apt-repository', '-y', 'ppa:ubuntu-toolchain-r/test'], check_rc=True)
-            irods_python_ci_utilities.subprocess_get_output(['sudo', 'update-java-alternatives', '--set', 'java-1.7.0-openjdk-amd64'])
-            irods_python_ci_utilities.install_os_packages(['libstdc++6'])
-
     irods_python_ci_utilities.install_os_packages(get_build_prerequisites())
 
 def install_messaging_package(message_broker):
@@ -66,7 +53,10 @@ def install_messaging_package(message_broker):
             irods_python_ci_utilities.subprocess_get_output(['wget', 'https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb'])
             irods_python_ci_utilities.subprocess_get_output(['sudo', 'dpkg', '-i', 'erlang-solutions_1.0_all.deb'])
             irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'update', '-y'])
-            irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'esl-erlang=1:19.3.6', '-y'])
+            if irods_python_ci_utilities.get_distribution_version_major() == '18':
+                irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'esl-erlang', '-y'])
+            else:
+                irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'esl-erlang=1:19.3.6', '-y'])
             irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'rabbitmq-server', '-y'])
 
         if irods_python_ci_utilities.get_distribution() == 'Centos' or irods_python_ci_utilities.get_distribution() == 'Centos linux':


### PR DESCRIPTION
Green for all OS'es.
Tested for Ubuntu 16 and 18; and CentOS 7 ; with custom build 4-2-qpid on d-w-moore/externals. 

This validates a new consortium build  # 2 for qpid-with-proton 

Solves https://github.com/irods/externals/issues/87

This PR should supercede https://github.com/irods/irods_rule_engine_plugin_audit_amqp/pull/45