### PR TITLE
[irods/irods#6437] Add support for new platforms (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_INIT "-Wl,--gc-sections -Wl,-z,combreloc")
 
 include(IrodsExternals)
 
-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(JANSSON jansson2.7-0)
 IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(QPID_PROTON qpid-proton0.36.0-0)
 
 string(REPLACE ";" ", " ${PLUGIN}_PACKAGE_DEPENDENCIES_STRING "${IRODS_PACKAGE_DEPENDENCIES_LIST}")
@@ -54,7 +53,6 @@ target_include_directories(
   ${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/include
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
   ${IRODS_EXTERNALS_FULLPATH_FMT}/include
-  ${IRODS_EXTERNALS_FULLPATH_JANSSON}/include
   ${IRODS_EXTERNALS_FULLPATH_QPID_PROTON}/include
   )
 
@@ -63,10 +61,10 @@ target_link_libraries(
   PRIVATE
   irods_server
   irods_common
-  ${IRODS_EXTERNALS_FULLPATH_JANSSON}/lib/libjansson.so
   ${IRODS_EXTERNALS_FULLPATH_QPID_PROTON}/lib/libqpid-proton.so
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+  nlohmann_json::nlohmann_json
   dl
   )
 

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -24,7 +24,6 @@ def install_building_dependencies(externals_directory):
         'irods-externals-cmake3.21.4-0',
         'irods-externals-cppzmq4.8.1-1',
         'irods-externals-fmt8.1.1-0',
-        'irods-externals-jansson2.7-0',
         'irods-externals-json3.10.4-0',
         'irods-externals-libarchive3.5.2-0',
         'irods-externals-nanodbc2.13.0-1',
@@ -50,14 +49,16 @@ def install_os_specific_dependencies_apt():
     irods_python_ci_utilities.install_os_packages(['libcurl4-gnutls-dev', 'make', 'libssl-dev', 'gcc'])
 
 def install_os_specific_dependencies_yum():
-    irods_python_ci_utilities.install_os_packages(['curl-devel', 'openssl-devel'])
+    irods_python_ci_utilities.install_os_packages(['make', 'curl-devel', 'openssl-devel'])
 
 def install_os_specific_dependencies():
     dispatch_map = {
-        'Ubuntu': install_os_specific_dependencies_apt,
-        'Centos': install_os_specific_dependencies_yum,
+        'Almalinux': install_os_specific_dependencies_yum,
         'Centos linux': install_os_specific_dependencies_yum,
+        'Centos': install_os_specific_dependencies_yum,
+        'Debian gnu_linux': install_os_specific_dependencies_apt,
         'Opensuse ': install_os_specific_dependencies_yum,
+        'Ubuntu': install_os_specific_dependencies_apt
     }
     try:
         return dispatch_map[irods_python_ci_utilities.get_distribution()]()

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -23,10 +23,12 @@ def get_build_prerequisites_zypper():
 
 def get_test_packages():
     dispatch_map = {
-        'Ubuntu': get_build_prerequisites_apt,
-        'Centos': get_build_prerequisites_yum,
+        'Almalinux': get_build_prerequisites_yum,
         'Centos linux': get_build_prerequisites_yum,
+        'Centos': get_build_prerequisites_yum,
+        'Debian gnu_linux': get_build_prerequisites_apt,
         'Opensuse': get_build_prerequisites_zypper,
+        'Ubuntu': get_build_prerequisites_apt
     }
     try:
         return dispatch_map[irods_python_ci_utilities.get_distribution()]()
@@ -46,7 +48,7 @@ def install_apache_activemq(message_broker):
 
 
 def install_rabbitmq(message_broker):
-    if irods_python_ci_utilities.get_distribution() == 'Ubuntu':
+    if irods_python_ci_utilities.get_distribution() in ['Ubuntu', 'Debian']:
         irods_python_ci_utilities.subprocess_get_output('curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.deb.sh | sudo bash', shell=True)
         irods_python_ci_utilities.subprocess_get_output(['wget', '-q', 'https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb'])
         irods_python_ci_utilities.subprocess_get_output(['sudo', 'dpkg', '-i', 'erlang-solutions_1.0_all.deb'])
@@ -57,7 +59,7 @@ def install_rabbitmq(message_broker):
             irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'esl-erlang=1:19.3.6', '-y'])
         irods_python_ci_utilities.subprocess_get_output(['sudo', 'apt-get', 'install', 'rabbitmq-server', '-y'])
 
-    if irods_python_ci_utilities.get_distribution() == 'Centos' or irods_python_ci_utilities.get_distribution() == 'Centos linux':
+    if irods_python_ci_utilities.get_distribution() in ['Centos', 'Centos linux', 'Almalinux']:
         irods_python_ci_utilities.subprocess_get_output(['sudo', 'rpm', '--rebuilddb'])
         irods_python_ci_utilities.subprocess_get_output('curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash', shell=True)
         irods_python_ci_utilities.subprocess_get_output('curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash', shell=True)


### PR DESCRIPTION
- Add new platforms to build and test hooks
- Remove JANSSON dependencies and add nlohmann:json to link libs

---

**This change is dependent on #96**

Confirmed that this builds on the new platforms with some tweaks. Test hook fails because the requested OpenJDK version is too old. Investigating now. Just putting this up here for eyeballs.