### PR TITLE
[#116] Revert "Use IrodsRunpathDefaults CMake module" (4-3-0-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ set(CMAKE_MODULE_LINKER_FLAGS_INIT "-Wl,--enable-new-dtags -Wl,--as-needed -Wl,-
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "-Wl,--enable-new-dtags -Wl,--as-needed -Wl,-z,defs")
 set(CMAKE_MODULE_LINKER_FLAGS_RELEASE_INIT "-Wl,--gc-sections -Wl,-z,combreloc")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_INIT "-Wl,--gc-sections -Wl,-z,combreloc")
-include(IrodsRunpathDefaults)
 
 include(IrodsExternals)
 
@@ -30,6 +29,13 @@ unset(IRODS_PACKAGE_DEPENDENCIES_LIST)
 project(irods_rule_engine_plugin-audit_amqp
   VERSION "${IRODS_PLUGIN_VERSION}"
   LANGUAGES CXX)
+
+set(CMAKE_SKIP_BUILD_RPATH OFF)
+set(CMAKE_SKIP_INSTALL_RPATH OFF)
+set(CMAKE_SKIP_RPATH OFF)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 
 include(${IRODS_TARGETS_PATH})
 


### PR DESCRIPTION
Perhaps supersedes https://github.com/irods/irods_rule_engine_plugin_audit_amqp/pull/117

The PRs are identical except for the name of the branch.