### PR TITLE
Add Rocky Linux to build hook (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,15 @@ After installing the plugin, `/etc/irods/server_config.json` needs to be configu
 Add a new stanza to the "rule_engines" array within `server_config.json`:
 
 ```json
-            {
-                "instance_name": "irods_rule_engine_plugin-audit_amqp-instance",
-                "plugin_name": "irods_rule_engine_plugin-audit_amqp",
-                "plugin_specific_configuration" : {
-                     "amqp_location" : "ANONYMOUS@localhost:5672",
-                     "amqp_topic" : "audit_messages",
-                     "pep_regex_to_match" : "audit_.*"
-                 }
-            },
-```
-
-Add the new `audit_` namespace to the "rule_engine_namespaces" array within `server_config.json`:
-
-```
-    "rule_engine_namespaces": [
-        "", 
-        "audit_"
-    ], 
+{
+    "instance_name": "irods_rule_engine_plugin-audit_amqp-instance",
+    "plugin_name": "irods_rule_engine_plugin-audit_amqp",
+    "plugin_specific_configuration" : {
+         "amqp_location" : "ANONYMOUS@localhost:5672",
+         "amqp_topic" : "audit_messages",
+         "pep_regex_to_match" : "pep_.+"
+     }
+}
 ```
 
 Further information on this plugin is described in the slide deck available here: http://slides.com/irods/ugm2016-auditing-rule-engine-amqp

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -58,6 +58,7 @@ def install_os_specific_dependencies():
         'Centos': install_os_specific_dependencies_yum,
         'Debian gnu_linux': install_os_specific_dependencies_apt,
         'Opensuse ': install_os_specific_dependencies_yum,
+        'Rocky linux': install_os_specific_dependencies_yum,
         'Ubuntu': install_os_specific_dependencies_apt
     }
     try:

--- a/sample_configuration.json
+++ b/sample_configuration.json
@@ -3,9 +3,9 @@
         "instance_name": "irods_rule_engine_plugin-audit_amqp-instance",
         "plugin_name": "irods_rule_engine_plugin-audit_amqp",
         "plugin_specific_configuration" : {
-            "pep_regex_to_match" : "audit_.*",
-            "amqp_topic" : "amq.topic",
             "amqp_location" : "localhost:5672",
+            "amqp_topic" : "amq.topic",
+            "pep_regex_to_match" : "pep_.+"
         }
     }
 ]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ namespace irods::plugin::rule_engine::audit_amqp
 		const auto pep_regex_flavor = std::regex::ECMAScript;
 
 		// NOLINTBEGIN(cert-err58-cpp, cppcoreguidelines-avoid-non-const-global-variables)
-		const std::string_view default_pep_regex_to_match{"audit_.*"};
+		const std::string_view default_pep_regex_to_match{"pep_.+"};
 		const std::string_view default_amqp_url{"localhost:5672/irods_audit_messages"};
 
 		const fs::path default_log_path_prefix{fs::temp_directory_path()};


### PR DESCRIPTION
It's not clear to me why we need the `audit_` namespace. The slides include it, but don't explain why.

Perhaps it's for demonstration purposes?