### PR TITLE
[irods/irods#7531] bump irods version requirement and switch to version range (4-3-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,13 @@
-cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR) #CPACK_DEBIAN_<COMPONENT>_PACKAGE_NAME
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR) #version range with find_package
 
 # Ensure try_compile() uses project settings
 cmake_policy(SET CMP0066 NEW)
 cmake_policy(SET CMP0067 NEW)
 
-find_package(IRODS 4.3.1 EXACT REQUIRED)
+set(IRODS_MINIMUM_VERSION "4.3.2")
+find_package(IRODS ${IRODS_MINIMUM_VERSION}...<4.4.0 REQUIRED)
 set(IRODS_PLUGIN_REVISION "0")
-set(IRODS_PLUGIN_VERSION "${IRODS_VERSION}.${IRODS_PLUGIN_REVISION}")
+set(IRODS_PLUGIN_VERSION "${IRODS_MINIMUM_VERSION}.${IRODS_PLUGIN_REVISION}")
 
 set(IRODS_PACKAGE_REVISION "0")
 


### PR DESCRIPTION
In service of irods/irods#7531

The usage of a version range here is due to the shift to libstdc++ in 4.9x. This plugin has a dependency on the qpid-proton C++ libraries, and must link to builds of said libraries that are built against the same C++ stdlib.

Merge irods/irods#7536 before merging this.
