### PR TITLE
[#138] Create log directory for testing before opening log file (4-3-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(
   nlohmann_json::nlohmann_json
   fmt::fmt
   ${IRODS_EXTERNALS_FULLPATH_QPID_PROTON}/lib/libqpid-proton-cpp.so
+  ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
   ${CMAKE_DL_LIBS}
   )


### PR DESCRIPTION
Allowed `test_audit_plugin.TestAuditPlugin.test_audit_plugin` to pass at the bench.